### PR TITLE
fix: get correct associated account address for stSOL

### DIFF
--- a/src/stake/ensureTokenAccount.ts
+++ b/src/stake/ensureTokenAccount.ts
@@ -1,9 +1,4 @@
-import {
-  ASSOCIATED_TOKEN_PROGRAM_ID,
-  createAssociatedTokenAccountInstruction,
-  getAssociatedTokenAddress,
-  TOKEN_PROGRAM_ID,
-} from '@solana/spl-token';
+import { createAssociatedTokenAccountInstruction, getAssociatedTokenAddress } from '@solana/spl-token';
 import { PublicKey, Transaction } from '@solana/web3.js';
 
 export const ensureTokenAccount = async (
@@ -12,24 +7,9 @@ export const ensureTokenAccount = async (
   stSolMint: PublicKey,
 ) => {
   // Creating the associated token account if not already exist
-  const associatedStSolAccount = await getAssociatedTokenAddress(
-    ASSOCIATED_TOKEN_PROGRAM_ID,
-    TOKEN_PROGRAM_ID,
-    false,
-    stSolMint,
-    payer,
-  );
+  const associatedStSolAccount = await getAssociatedTokenAddress(stSolMint, payer, false);
 
-  transaction.add(
-    createAssociatedTokenAccountInstruction(
-      ASSOCIATED_TOKEN_PROGRAM_ID,
-      TOKEN_PROGRAM_ID,
-      stSolMint,
-      associatedStSolAccount,
-      payer,
-      payer,
-    ),
-  );
+  transaction.add(createAssociatedTokenAccountInstruction(payer, associatedStSolAccount, payer, stSolMint));
 
   return associatedStSolAccount;
 };


### PR DESCRIPTION
The order of the arguments passed into the associated token account functions are wrong, resulting in broken staking transactions being built when user does not yet have a stSOL token account. This PR fixes that issue.